### PR TITLE
Consistent trade data type for Binance

### DIFF
--- a/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
@@ -265,26 +265,26 @@ namespace ExchangeSharp
         protected override IWebSocket OnGetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] marketSymbols)
         {
             /*
-            {
-              "e": "trade",     // Event type
-              "E": 123456789,   // Event time
-              "s": "BNBBTC",    // Symbol
-              "t": 12345,       // Trade ID
-              "p": "0.001",     // Price
-              "q": "100",       // Quantity
-              "b": 88,          // Buyer order Id
-              "a": 50,          // Seller order Id
-              "T": 123456785,   // Trade time
-              "m": true,        // Is the buyer the market maker?
-              "M": true         // Ignore.
-            }
+	    {
+	      "e": "aggTrade",  // Event type
+	      "E": 123456789,   // Event time
+	      "s": "BNBBTC",    // Symbol
+	      "a": 12345,       // Aggregate trade ID
+	      "p": "0.001",     // Price
+	      "q": "100",       // Quantity
+	      "f": 100,         // First trade ID
+	      "l": 105,         // Last trade ID
+	      "T": 123456785,   // Trade time
+	      "m": true,        // Is the buyer the market maker?
+	      "M": true         // Ignore
+	    }
             */
 
             if (marketSymbols == null || marketSymbols.Length == 0)
             {
                 marketSymbols = GetMarketSymbolsAsync().Sync().ToArray();
             }
-            string url = GetWebSocketStreamUrlForSymbols("@trade", marketSymbols);
+            string url = GetWebSocketStreamUrlForSymbols("@aggTrade", marketSymbols);
             return ConnectWebSocket(url, (_socket, msg) =>
             {
                 JToken token = JToken.Parse(msg.ToStringFromUTF8());


### PR DESCRIPTION
Binances live data stream is currently set to use the RAW trade data while the historical data is set to use the AGGREGATED data.

This pull request brings the live data stream inline with the more useful AGGREGATED datatype.

One could argue that for regression purposes it should be other way around, which then simply means the historical data should use the RAW data as well.

Either is fine, as long as it's consistent.